### PR TITLE
fix: pin numpy for torch 1.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,10 @@ cd DeOldify
 conda env create -f environment.yml
 ```
 
+This project is currently built against PyTorch 1.11.0 which does not
+support NumPy 2.x. If you install the environment manually ensure that
+`numpy` is kept below version 2.
+
 Then start running with these commands:
 
 ```console

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
 - pip
 - fastai=1.0.60
+- numpy<2
 - mkl=2024.0
 - python=3.10
 - pytorch::pytorch=1.11.0

--- a/requirements-colab.txt
+++ b/requirements-colab.txt
@@ -1,4 +1,5 @@
 fastai==1.0.60
+numpy<2
 tensorboardX>=1.6
 ffmpeg-python
 yt-dlp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 wandb
+numpy<2
 fastai==1.0.60
 tensorboardX>=1.6
 ffmpeg


### PR DESCRIPTION
## Summary
- ensure numpy remains below version 2 across requirements
- document the numpy limitation in the README
