### PR TITLE
feat: add lightweight CPU-only Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,12 +582,40 @@ docker run -it -v $(pwd):/app/video deoldify python VideoColorizer.py
 ```
 Also good for mounting the source code to achieve faster dev iterations.
 
+### CPU-only lightweight image
+
+For environments without GPU support, a slim image is provided that contains only
+the essentials for running `VideoColorizer.py` on the CPU.
+
+Build the image:
+
+```bash
+cd docker/cpu
+./build.sh
+```
+
+Run the colorizer on all videos in `video/source` of the mounted directory:
+
+```bash
+docker run --rm -v ${PWD}:/app/video deoldify-cpu
+```
+
+The script uses the `DEOLDIFY_DEVICE` environment variable if set; otherwise it
+defaults to CPU, making this container work out of the box on machines without
+hardware acceleration.
+
 ## Roadmap
 
 - skip files that were already colorized
 - example notebooks for new architectures and training recipes.
 - continue aborted colorizations (in case of a power outage or whatever else)
 - ONNX exporter w/ `torch-directml`
+
+### Lightweight CPU Docker
+
+- Pre-build images for multiple platforms
+- Add image colorization support
+- Integrate automated testing for container builds
 
 ### Cross-Platform GPU Support
 

--- a/VideoColorizer.py
+++ b/VideoColorizer.py
@@ -1,8 +1,14 @@
 #NOTE:  This must be the first call in order to work properly!
+import os  # Allow device selection via environment variable
 from deoldify import device
 from deoldify.device_id import DeviceId
-#choices:  CPU, GPU0...GPU7
-device.set(device=DeviceId.GPU0)
+# choices:  CPU, GPU0...GPU7
+# Default to CPU so this script works in lightweight containers
+_device_str = os.getenv("DEOLDIFY_DEVICE", "CPU").upper()
+try:
+    device.set(device=DeviceId[_device_str])
+except KeyError:
+    device.set(device=DeviceId.CPU)
 
 import torch
 print("CUDA available: " + str(torch.cuda.is_available()))
@@ -23,7 +29,6 @@ source_url = None
 #source_url='https://twitter.com/silentmoviegifs/status/1116751583386034176'
 
 # read and process the entire video folder
-import os
 import subprocess
 folder_path = 'video/source'
 result_path = None

--- a/docker/cpu/Dockerfile
+++ b/docker/cpu/Dockerfile
@@ -1,0 +1,31 @@
+# Lightweight CPU-only image for DeOldify video colorization
+FROM python:3.10-slim
+
+# Set working directory inside the container
+WORKDIR /app
+
+# Avoid interactive prompts during package installs
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install minimal system dependencies and ffmpeg
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg libgl1 libglib2.0-0 libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy project files into the container
+COPY . .
+
+# Install only the Python packages needed for CPU inference
+RUN pip install --no-cache-dir -r requirements-cpu.txt
+
+# Fetch the video model weights; this avoids download at runtime
+RUN wget https://data.deepai.org/deoldify/ColorizeVideo_gen.pth -O ./models/ColorizeVideo_gen.pth
+
+# Warm up the model once so that supporting weights are cached
+RUN python - <<'PY'
+from deoldify.visualize import get_video_colorizer
+get_video_colorizer()
+PY
+
+# Process all videos found in /app/video/source when the container runs
+CMD ["python", "VideoColorizer.py"]

--- a/docker/cpu/build.bat
+++ b/docker/cpu/build.bat
@@ -1,0 +1,3 @@
+@echo off
+REM Build the lightweight CPU-only DeOldify image
+docker build -t deoldify-cpu -f ./Dockerfile ..

--- a/docker/cpu/build.sh
+++ b/docker/cpu/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Build the lightweight CPU-only DeOldify image
+set -e
+
+docker build -t deoldify-cpu -f ./Dockerfile ..

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,0 +1,10 @@
+# Minimal dependencies for CPU-only container
+numpy>=1.21,<1.24
+fastai==1.0.60
+tensorboardX>=1.6
+ffmpeg-python
+yt-dlp
+opencv-python>=4.2.0.32
+Pillow==9.3.0
+torch==1.11.0
+torchvision==0.12.0


### PR DESCRIPTION
## Summary
- add CPU-first VideoColorizer behavior with optional `DEOLDIFY_DEVICE`
- introduce minimal `docker/cpu` image and build scripts
- document CPU container usage and outline its future roadmap

## Testing
- `tox -e format` *(fails: would reformat files)*
- `tox -e static` *(fails: proxy error during dependency install)*

------
https://chatgpt.com/codex/tasks/task_e_68a2eb2a86b48329aa1c17ab4693edcb